### PR TITLE
Fix refreshing of OAuth2 tokens in Sentry 9+

### DIFF
--- a/sentry_auth_gitlab/provider.py
+++ b/sentry_auth_gitlab/provider.py
@@ -12,6 +12,8 @@ from .views import FetchUser
 
 class GitLabOAuth2Provider(OAuth2Provider):
     name = 'GitLab'
+    client_id = CLIENT_ID
+    client_secret = CLIENT_SECRET
 
     def get_auth_pipeline(self):
         return [


### PR DESCRIPTION
Sentry has a background job that checks the state of all OAuth2
identities.  If the OAuth2 refresh protocol doesn't work, it marks the
identity as needing to reauthenticate.

The refresh protocol was failing because the `client_id` and
`client_secret` were not set in
https://github.com/getsentry/sentry/blob/8f717ad1198aa1549bf799b72efe880704f1c6fc/src/sentry/auth/providers/oauth2.py#L153-L154.